### PR TITLE
Content-Length should be length of byte array

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "coffee-script": "^1.10.0",
     "https-proxy-agent": "^1.0.0",
     "log": "^1.4.0",
-    "ws": "^1.0.1"
+    "ws": "^1.0.1",
+    "text-encoding": "^0.5.5"
   },
   "engines": {
       "node": ">= 0.10.x",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -1,6 +1,7 @@
 https       = require 'https'
 querystring = require 'querystring'
 WebSocket   = require 'ws'
+TextEncoder = require 'text-encoding'
 Log            = require 'log'
 {EventEmitter} = require 'events'
 pingInterval = 60000
@@ -218,7 +219,7 @@ class Client extends EventEmitter
             path: '/api/v1' + path
             headers:
                 'Content-Type': 'application/json'
-                'Content-Length': post_data.length
+                'Content-Length': new TextEncoder.TextEncoder('utf-8').encode(post_data).length
         options.headers['Authorization'] = 'BEARER '+@token if @token
 
         req = https.request(options)


### PR DESCRIPTION
Posting messages with unicode characters was not possible, because the content length was wrong. Fix  Issue #1 