### PR TITLE
Allow SSL connections sans-verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following environment variables may be defined to alter behavior:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| MATTERMOST\_SSL\_NOVERIFY | No | Allow connections when certs can not be verified (ie: self-signed, etc. - MITM risks) |
+| MATTERMOST\_SSL\_NOVERIFY | No | set to 'true' to allow connections when certs can not be verified (ie: self-signed, etc. - MITM risks) |
 | MATTERMOST\_LOG\_LEVEL | No | set log level (default=info) |
 
 ## Mattermost 3.0

--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ The initial implementation thus contains only the minimal set of API calls to su
 - Can be invited to channels / DMs since its just a regular user
 - Initiate DMs to users
 
+## Environment variables
+
+The following environment variables may be defined to alter behavior:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| MATTERMOST\_SSL\_NOVERIFY | No | Allow connections when certs can not be verified (ie: self-signed, etc. - MITM risks) |
+| MATTERMOST\_LOG\_LEVEL | No | set log level (default=info) |
+
 ## Mattermost 3.0
 
 This client always tries to track the latest version of Mattermost.
-As verion `3.x` of Mattermost is a major release and introduces backwards incompatible changes make sure you 
+As verion `3.x` of Mattermost is a major release and introduces backwards incompatible changes make sure you
 are using the latest version of this library.
 
 ## Older versions

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -119,6 +119,7 @@ class Client extends EventEmitter
         @_connecting = true
         @logger.info 'Connecting...'
         options =
+            rejectUnauthorized: JSON.parse(process.env.MATTERMOST_SSL_NOVERIFY or 'false')
             headers: {authorization: "BEARER " + @token}
 
         # Set up websocket connection to server
@@ -296,6 +297,7 @@ class Client extends EventEmitter
             hostname: @host
             method: method
             path: apiPrefix + path
+            rejectUnauthorized: JSON.parse(process.env.MATTERMOST_SSL_NOVERIFY or 'false')
             headers:
                 'Content-Type': 'application/json'
                 'Content-Length': new TextEncoder.TextEncoder('utf-8').encode(post_data).length


### PR DESCRIPTION
This change makes it possible to set the rejectUnauthorized option on the https client request.

This is for those situations where one finds themselves in an intranet, unable to use LetsEncrypt and must use internal CA-signed certs and/or self-signed certs.