### PR TITLE
Fix http/https connect error and add support ws(non wss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following environment variables may be defined to alter behavior:
 |----------|----------|-------------|
 | MATTERMOST\_TLS\_VERIFY | No | (default: true) set to 'false' to allow connections when certs can not be verified (ex: self-signed, internal CA, ... - MITM risks) |
 | MATTERMOST\_LOG\_LEVEL | No | (default: info) set log level (also: debug, ...) |
+| MATTERMOST\_USE\_TLS | No | (default: true) set to 'false' to use http/ws instead of https/wss |
 
 ## Mattermost 3.0
 


### PR DESCRIPTION
Fix incorrect usage of request.js. http and https request failed because
need to include "https://" or "http://" in uri on request.js.
Add support ws(non wss).
Add MATTERMOST_USE_TLS environment variable.