### PR TITLE
Implement update header API call

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -288,6 +288,14 @@ class Client extends EventEmitter
             @logger.debug 'Posted message.'
             return true
 
+    setChannelHeader: (channelID, header) ->
+        postData =
+            channel_id: channelID
+            channel_header: header
+
+        @_apiCall 'POST', @teamRoute() + '/channels/update_header', postData, (data, header) =>
+            @logger.debug 'Channel header updated.'
+            return true
 
     # Private functions
     #


### PR DESCRIPTION
Hello! I'm trying to add a script to my hubot that can, based on a webhook, update a channel header with arbitrary information (in my case, the engineer on-call) To do this, I need to implement the change-header API in the client and in the matteruser adapter.

It's pretty straight forward, all you need to pass the function is the channel ID (I'm not sure if this is something the adapter or the hubot script should do - please weigh in on your preference here) and the header text to update the channel with. 