### PR TITLE
Skip login if token provided

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -42,7 +42,11 @@ class Client extends EventEmitter
 
     login: ->
         @logger.info 'Logging in...'
-        @_apiCall 'POST', usersRoute + '/login', {login_id: @email, password: @password}, @_onLogin
+        if @token?
+          # no need to login so just pass user info
+          @_apiCall 'GET', usersRoute + '/me', {login_id: @email, password: @password}, @_onLogin
+        else
+          @_apiCall 'POST', usersRoute + '/login', {login_id: @email, password: @password}, @_onLogin
 
     _onLogin: (data, headers) =>
         if data


### PR DESCRIPTION
Here's the missing part for #35. In my environment, we have mandatory MFA so I log in as the bot, entering TOTP manually, pull the `MMAUTHTOKEN` cookie and use it for `MATTERMOST_TOKEN`, then the bot is good to go. According to https://api.mattermost.com/#tag/authentication, It looks like there's a way to use login API with MFA token, but I haven't figured it out.