### PR TITLE
made the team name comparison at startup be case insensitive

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -73,7 +73,7 @@ class Client extends EventEmitter
             @logger.debug 'Found '+Object.keys(@teams).length+' teams.'
             for t in @teams
                 @logger.debug "Testing #{t.name} == #{@group}"
-                if t.name == @group
+                if t.name.toLowerCase() == @group.toLowerCase()
                     @logger.debug "Found team! #{t.id}"
                     @teamID = t.id
                     break


### PR DESCRIPTION
The internal mattermost representation of the team name is all lower-case, regardless of the case used when creating the team. 
This can cause problems if the team name in the environment variable for is not set to all lower-case.
This change takes care of that.