### PR TITLE
fix getChannelByID now that 'channels' is an object mapping id to channel

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -309,7 +309,7 @@ class Client extends EventEmitter
         @channels
 
     getChannelByID: (id) ->
-        (i for i in @channels when i.id is id)[0]
+        @channels[id]
 
     customMessage: (postData, channelID) ->
         if postData.message?


### PR DESCRIPTION
I believe this was broken in commit e6956300dc9cce32860566e6b2007f18e5e486f0