### PR TITLE
Fix issues on the 3 methods

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -81,7 +81,7 @@ class Client extends EventEmitter
 
     _onLoadUser: (data, headers, params) =>
         if data && not data.error
-          @users[data.id] = user
+          @users[data.id] = data
           @emit 'profilesLoaded', [data]
 
     _onChannels: (data, headers, params) =>

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -324,12 +324,11 @@ class Client extends EventEmitter
               return @customMessage(postData, channelID)
             return true
 
-    createDirectChannel: (userID) ->
-        postData =
-            user_id: userID
-        @_apiCall 'POST', @channelRoute('create_direct'), postData, (data, headers) =>
-            @logger.debug 'Created Direct Channel.'
-            return data
+    createDirectChannel: (userID, callback) ->
+        postData = [userID, @self.id]
+        @_apiCall 'POST', '/channels/direct', postData, (data, headers) =>
+            @logger.info 'Created Direct Channel.'
+            if callback? then callback(data)
 
     findChannelByName: (name) ->
         for c of @channels
@@ -406,7 +405,8 @@ class Client extends EventEmitter
                 if callback? then callback({'id': null, 'error': error.errno}, {}, callback_params)
             else
                 if callback?
-                    if res.statusCode is 200
+                    # some create method return 201 when successful, such as create channel
+                    if res.statusCode is 200 or res.statusCode is 201
                         if typeof value == 'string'
                             value = JSON.parse(value)
                         callback(value, res.headers, callback_params)


### PR DESCRIPTION
@loafoe I found some method can't work on mattermost 4.0. just fixed it, pls check it.

**_onLoadUser**, there is a code issue on it. 

**getUserDirectMessageChannel**, can' get channel for any new channel which have to call createDirectChannel, and we have to pass the callback to createDirectChannel.

**createDirectChannel**, it should accept a callback parameter; and also the url is incorrect.

**_apiCall**,  when call /channels/direct, the success status code is 201 instead of 200. 

You can see the latest api code here. https://api.mattermost.com/#tag/channels%2Fpaths%2F~1channels~1direct%2Fpost
