### PR TITLE
Fix reconnect when using personal access token

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -333,7 +333,7 @@ class Client extends EventEmitter {
         return setTimeout(() => {
             this.logger.info('Attempting reconnect');
             if (this.personalAccessToken) {
-              return this.tokenLogin(this.personalAccessToken)
+              return this.tokenLogin(this.token)
             }
             return this.login(this.email, this.password, this.mfaToken);
         }


### PR DESCRIPTION
Connections with personal access token could not reconnect because of invalid parameter for `tokenLogin`. Passing an actual token instead of a boolean flag.