### PR TITLE
load all users from server

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -227,6 +227,13 @@ class Client extends EventEmitter {
         return this._apiCall('GET', uri, null, this._onLoadUsers, { page });
     }
 
+    loadAllUsers(page) {
+        if (page == null) { page = 0; }
+        const uri = `/users?page=${page}&per_page=200`;
+        this.logger.info(`Loading ${uri}`);
+        return this._apiCall('GET', uri, null, this._onLoadUsers, { page });
+    }
+
     loadUser(user_id) {
         const uri = `/users/${user_id}`;
         this.logger.info(`Loading ${uri}`);


### PR DESCRIPTION
The loadUsers function loads only the users form your teams from the server. 
As it's possible to pm all users on the server I added this method to load all users on the server.