### PR TITLE
support 'type' for message

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -592,6 +592,9 @@ class Client extends EventEmitter {
             if (msg.file_ids) {
                 postData.file_ids = msg.file_ids;
             }
+            if (msg.type) {
+                postData.type = msg.type;
+            }
         }
 
         // break apart long messages


### PR DESCRIPTION
The latest mattermost, Post support a new field 'type'.  User can install plugin to show the new type post. please refer to,
https://developers.mattermost.com/integrate/plugins/webapp/reference/#registerPostTypeComponent